### PR TITLE
Reorder setting if you aren't using S3 so drag upload registers the non-S3 setting correctly

### DIFF
--- a/dragupload.js
+++ b/dragupload.js
@@ -1,4 +1,15 @@
 Hooks.once('init', async () => {
+
+    game.settings.register("dragupload", "fileUploadFolder", {
+        name: "The path files should be uploaded to",
+        hint: "Should look like 'dragupload/uploaded'",
+        scope: "world",
+        config: true,
+        type: String,
+        default: "dragupload/uploaded",
+        onChange: async () => { await initializeDragUpload(); }
+    });
+    
     const usingTheForge = typeof ForgeVTT != "undefined" && ForgeVTT.usingTheForge;
 
     game.settings.register("dragupload", "fileUploadSource", {
@@ -26,16 +37,6 @@ Hooks.once('init', async () => {
         type: String,
         default: usingTheForge ? "" : (FilePicker.S3_BUCKETS?.length > 0 ? FilePicker.S3_BUCKETS[0] : ""),
         choices: bucketChoices,
-        onChange: async () => { await initializeDragUpload(); }
-    });
-
-    game.settings.register("dragupload", "fileUploadFolder", {
-        name: "The path files should be uploaded to",
-        hint: "Should look like 'dragupload/uploaded'",
-        scope: "world",
-        config: true,
-        type: String,
-        default: "dragupload/uploaded",
         onChange: async () => { await initializeDragUpload(); }
     });
 });


### PR DESCRIPTION
Currently this error happens before reordering. 

```
dragupload.js:42 
 Uncaught (in promise) The requested file storage s3 does not exist!
(anonymous)	@	dragupload.js:42
await in (anonymous) (async)		
_call	@	foundry.js:294
callAll	@	foundry.js:253
initialize	@	foundry.js:5368
🎁call_wrapped	@	libWrapper-wrapper.js:502
🎁libWrapperInit	@	libWrapper-api.js:778
await in 🎁libWrapperInit (async)		
🎁Game.prototype.initialize#0	@	libWrapper-wrapper.js:182
window.addEventListener.once	@	foundry.js:62192
```