### PR TITLE
Fix for DragUpload to sometimes treat dragging an actor as if it was an image

### DIFF
--- a/dragupload.js
+++ b/dragupload.js
@@ -155,7 +155,8 @@ async function handleDrop(event) {
         file = files[0]
     }
 
-    if (file == undefined) {
+    // file.path won't be set if it's an image dragged from within foundry itself instead of dragged from the OS
+    if (file == undefined || !file.path) {
         // Let Foundry handle the event instead
         canvas._onDrop(event);
         return;


### PR DESCRIPTION
Sometimes if you drag the icon representing an actor onto the main canvas, drag upload will think you are trying to add a new image instead of the actor itself.  Dragging from the name of the actor works around this, but is a but clunky.

This may not be the best way to detect this scenario, it took some trial and error to find a way that worked reliably.

This should fix issues #62, #64, #58, #55, #52, #48, #34
